### PR TITLE
不具合対応：プロダクションにて、ホーム画面で1分以上放置すると、アプリケーションがエラーになる

### DIFF
--- a/src/main/java/com/yuri/gongbu/util/HomeApiUtil.java
+++ b/src/main/java/com/yuri/gongbu/util/HomeApiUtil.java
@@ -17,20 +17,20 @@ public class HomeApiUtil {
     public static String getWordRandom(List<WordHomeResponseDto> wordsList, List<Integer> postedWords) {
         List<Integer> wordsId = wordsList.stream().map(word -> word.getWordId()).collect(Collectors.toList());
         Random random = new Random();
-        int randomWordId = random.nextInt(wordsId.size());
+        int randomWordId = wordsId.get(random.nextInt(wordsId.size()));
 
         if (postedWords.size() == GlobalVariable.POSTED_WORDS_MAX_SIZE) {
             postedWords.removeAll(postedWords);
         }
 
-        while (postedWords.contains(randomWordId)){
-            randomWordId = random.nextInt(wordsId.size());
+        while (postedWords.size() > GlobalVariable.POSTED_WORDS_MAX_SIZE && postedWords.contains(randomWordId)){
+            randomWordId = wordsId.get(random.nextInt(wordsId.size()));
         }
         postedWords.add(randomWordId);
 
         WordHomeResponseDto randomWord = null;
         for (WordHomeResponseDto dto : wordsList) {
-            if(dto.getWordId() == wordsList.get(randomWordId).getWordId()){
+            if(dto.getWordId() == randomWordId){
                 randomWord = dto;
             }
         }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -53,21 +53,21 @@
       </div>
     </div>
     <script type="text/javascript" th:inline="javascript">
-      // setInterval(randomWordCall, 5000);
+      setInterval(randomWordCall, 5000);
 
-      // function randomWordCall() {
-      //   $.ajax({
-      //     url: '/word/random',
-      //     type: 'get',
-      //   }).done(function (data) {
-      //     const randomWord = JSON.parse(data);
-      //     var context = window.location.pathname.substring(0, window.location.pathname.indexOf("/",2)); 
-      //     var url =window.location.protocol+"//"+ window.location.host +context+"/word/detail/" + randomWord.wordId;
+      function randomWordCall() {
+        $.ajax({
+          url: '/word/random',
+          type: 'get',
+        }).done(function (data) {
+          const randomWord = JSON.parse(data);
+          var context = window.location.pathname.substring(0, window.location.pathname.indexOf("/",2)); 
+          var url =window.location.protocol+"//"+ window.location.host +context+"/word/detail/" + randomWord.wordId;
 
-      //     $("#cardWord").html(randomWord.wordName);
-      //     $(".cardWordLink").attr("href", url);
-      //   });
-      // }
+          $("#cardWord").html(randomWord.wordName);
+          $(".cardWordLink").attr("href", url);
+        });
+      }
     </script>
   </th:block>  
 </html>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -53,21 +53,21 @@
       </div>
     </div>
     <script type="text/javascript" th:inline="javascript">
-      setInterval(randomWordCall, 5000);
+      // setInterval(randomWordCall, 5000);
 
-      function randomWordCall() {
-        $.ajax({
-          url: '/word/random',
-          type: 'get',
-        }).done(function (data) {
-          const randomWord = JSON.parse(data);
-          var context = window.location.pathname.substring(0, window.location.pathname.indexOf("/",2)); 
-          var url =window.location.protocol+"//"+ window.location.host +context+"/word/detail/" + randomWord.wordId;
+      // function randomWordCall() {
+      //   $.ajax({
+      //     url: '/word/random',
+      //     type: 'get',
+      //   }).done(function (data) {
+      //     const randomWord = JSON.parse(data);
+      //     var context = window.location.pathname.substring(0, window.location.pathname.indexOf("/",2)); 
+      //     var url =window.location.protocol+"//"+ window.location.host +context+"/word/detail/" + randomWord.wordId;
 
-          $("#cardWord").html(randomWord.wordName);
-          $(".cardWordLink").attr("href", url);
-        });
-      }
+      //     $("#cardWord").html(randomWord.wordName);
+      //     $(".cardWordLink").attr("href", url);
+      //   });
+      // }
     </script>
   </th:block>  
 </html>


### PR DESCRIPTION
### 状況
プロダクション環境でホーム画面に移動し、そのまま2分間放置すると以下のエラーになり、
その後はDBの接続に関する画面(ホーム、ことば一覧、ことばリスト等など)が全部落ちてしまう😢
```
WARN  2022-06-30 08:20:19.025 : [            SqlExceptionHelper:137] - SQL Error: 0, SQLState: null
ERROR 2022-06-30 08:20:19.027 : [            SqlExceptionHelper:142] - HikariPool-1 - Connection is not available, request timed out after 30003ms.
ERROR 2022-06-30 08:20:19.307 : [           [dispatcherServlet]:175] - Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed; nested exception is org.springframework.dao.DataAccessResourceFailureException: Unable to acquire JDBC Connection; nested exception is org.hibernate.exception.JDBCConnectionException: Unable to acquire JDBC Connection] with root cause
java.sql.SQLTransientConnectionException: HikariPool-1 - Connection is not available, request timed out after 30003ms.
```
### 原因
https://jaehun2841.github.io/2020/01/27/2020-01-27-hikaricp-maximum-pool-size-tuning/
↑を読んでエラーメッセージの意味が分かった(一応、韓国語のページなんです 😅 )
要するにHikariCPのコネクションプールが足りなくて上記のエラーになるようだ。
で、自分のコードで原因になる部分を見つけた。
```
while (postedWords.contains(randomWordId)){
            randomWordId = wordsId.get(random.nextInt(wordsId.size()));
        }
```
ことばが12個未満のとき、HomeApiUtil. getWordRandomの上の部分でwhile分を抜けずに処理がグルグル回る。
上記の処理が解決されないのに5秒ごとにHomeApiUtil. getWordRandomが呼ばれて、同じくwhileに閉じこまれる。
で、結局コネクションプールがなくなり、エラー発生！
### 対応
参考にした記事では数式を使って、コネクションプールを指定するように書いてあったが、
私の場合はコネクションプールを増やしてもwhile分を抜けなかったら、またエラーになるので、
ことばが12個未満のとき、1分後の再表示制約を適しないように修正した。
https://github.com/crane93/gongbu/blob/1e8ed01e2d502194545dd38ca49d7d6302563bf9/src/main/java/com/yuri/gongbu/util/HomeApiUtil.java#L26-L28